### PR TITLE
fancy quote characters on about page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,9 +61,9 @@ android {
 dependencies {
     compile 'com.android.support:support-v4:21.0.3'
     compile 'com.google.android.gms:play-services:6.5.87'
-    compile 'com.android.support:appcompat-v7:21.0.+'
+    compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.android.support:cardview-v7:21.0.3'
-    compile 'com.android.support:recyclerview-v7:21.0.+'
+    compile 'com.android.support:recyclerview-v7:21.0.3'
     compile 'com.vividsolutions:jts:1.13'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.1'
 

--- a/app/src/main/assets/legal/legal.html
+++ b/app/src/main/assets/legal/legal.html
@@ -119,7 +119,7 @@
     <h2>Privacy Notices</h2>
 
     <p>
-      This Policy may be supplemented or amended from time to time and NGA will notify you by issuing “privacy notices.”
+      This Policy may be supplemented or amended from time to time and NGA will notify you by issuing "privacy notices."
       These Privacy Notices will provide a level of detail describing the changes in our policy and how they may affect you.
       For example, this App may issue Privacy Notices providing details about changes in the function and use of the PII
       we collect, and why we need that information.


### PR DESCRIPTION
This pull request replaces some fancy quotes with normal ASCII quotes on the About DICE page because the quotes did not display correctly on some devices.